### PR TITLE
Bump to v0.13.1: v_triangle and vignette fixes

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: tbl.now
 Type: Package
 Title: Tidy Extension for Nowcasting
-Version: 0.13.0
+Version: 0.13.1
 Authors@R: 
     c(person("Rodrigo", "Zepeda-Tello", , "rzepeda17@gmail.com", role = c("aut", "cre"),
            comment = c(ORCID = "0000-0003-4471-5270")),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,8 @@
+# tbl.now 0.13.1
+
+* Fixed style in the batch reporting vignette
+* Improved the axis title position in the v triangle to better visualize the dates
+
 # tbl.now 0.13.0
 
 * Bug fix: `batch_shape_test()` no longer errors ("missing value where TRUE/FALSE

--- a/R/v_triangle.R
+++ b/R/v_triangle.R
@@ -117,8 +117,8 @@ plot_reporting_v <- function(x, max_delay = NULL, point_size = NULL,
 
   p <- ggplot2::ggplot(grid, ggplot2::aes(.data$x, .data$y)) +
     ggplot2::geom_hline(yintercept = r_rel, colour = "grey92", linewidth = 0.3) +
-    ggplot2::geom_point(data = zeros, colour = .DIAG_ZERO_COLOUR, shape = 25, size = psize) +
-    ggplot2::geom_point(data = positive, ggplot2::aes(colour = .data$n), shape = 25, size = psize) +
+    ggplot2::geom_point(data = zeros, colour = .DIAG_ZERO_COLOUR, shape = 12, size = psize) +
+    ggplot2::geom_point(data = positive, ggplot2::aes(colour = .data$n), shape = 12, size = psize) +
     ggplot2::scale_colour_gradient(name = "reports", low = "grey80",
                                    high = palette[["accent_red"]], transform = "sqrt",
                                    labels = scales::label_comma()) +
@@ -134,11 +134,11 @@ plot_reporting_v <- function(x, max_delay = NULL, point_size = NULL,
                        angle = 45, hjust = 1, size = 2.6, colour = "grey30") +
     ggplot2::geom_text(data = dl_ticks, ggplot2::aes(.data$lx, .data$ly, label = .data$lab),
                        angle = -45, hjust = 0, size = 2.6, colour = "grey30") +
-    ggplot2::annotate("text", x = ev_title[["x"]], y = ev_title[["y"]],
-                      label = "event date", angle = -45, fontface = "bold",
+    ggplot2::annotate("text", x = ev_title[["x"]], y = e_top, angle = -45,
+                      label = "event date", fontface = "bold",
                       colour = "grey25", size = 3.4) +
-    ggplot2::annotate("text", x = dl_title[["x"]], y = dl_title[["y"]],
-                      label = "delay", angle = 45, fontface = "bold",
+    ggplot2::annotate("text", x = dl_title[["x"]], y = e_top, angle = 45,
+                      label = "delay", fontface = "bold",
                       colour = "grey25", size = 3.4) +
     ggplot2::scale_y_continuous(breaks = r_rel, labels = format(r_breaks)) +
     ggplot2::coord_fixed(ratio = 1, clip = "off") +
@@ -149,6 +149,7 @@ plot_reporting_v <- function(x, max_delay = NULL, point_size = NULL,
     .tbl_now_theme(palette) +
     ggplot2::theme(axis.text.x = ggplot2::element_blank(),
                    axis.ticks.x = ggplot2::element_blank(),
+                   axis.title.y = ggplot2::element_text(face = "bold"),
                    panel.grid = ggplot2::element_blank(),
                    legend.text = ggplot2::element_text(hjust = 0.5, vjust = 1, angle = 90),
                    legend.box.margin = ggplot2::margin(0, 0, 0, 20),

--- a/vignettes/articles/batch-reporting.Rmd
+++ b/vignettes/articles/batch-reporting.Rmd
@@ -229,8 +229,7 @@ plot_epidemic_process(tn) + plot_reporting_process(tn)
 
 ## The reporting process
 
-This plot, which we have previously shown, shows how many reports arrived by date. Barches or surges might correspond
-to spikes towering over their neighbours. 
+This plot, which we have previously shown, shows how many reports arrived by date. Batches or surges might correspond to spikes towering over their neighbours. 
 
 ```{r, fig.cap="Reporting process of the simulated data"}
 plot_reporting_process(ideal)
@@ -288,29 +287,23 @@ so that the report date is the main vertical axis.  Here batches
 that were diagonals in the previous interpretation are horizontal slices 
 where the reporting dates can be seen more easily.
 
-```{r v-sim, eval = FALSE}
+```{r v-sim, eval = TRUE}
 plot_reporting_v(ideal)
 ```
-```{r, echo = FALSE}
-plot_reporting_v(ideal) + plot_reporting_process(ideal)
-```
+
 
 On covid the V opens into a full wedge; the potential batches are the faint horizontal
 streaks in June 2020.
 
-```{r v-covid, eval = FALSE}
+```{r v-covid, eval = TRUE}
 plot_reporting_v(tn)
 ```
 
-```{r v-covid2, echo = FALSE}
-plot_reporting_v(tn) + plot_reporting_process(tn)
-```
 
 ## Scalograms
 
 ::: {.alert .alert-warning}
-The scalogram functions are **very experimental**. We have yet to confirm they work for all batch cases. Feel free to skip
-to the @sec-transport
+The scalogram functions are **very experimental**. We have yet to confirm they work for all batch cases. Feel free to skip to the section on [transport](https://rodrigozepeda.github.io/tbl.now/articles/batch-reporting.html#sec-transport)
 :::
 
 Scalograms show reductions of cases. For this example, consider the following simulated reporting  process:
@@ -368,8 +361,8 @@ each day. Three things can change the number of reports:
 - a **batch** -- the day the backlog (hold) is finally released, all at once;
 - a **surge** -- an increase in the epidemic process: more people falling ill and being reported.
 
-We simulate one of each in a clean epidemic and colour every day by which it is (grey
-= an ordinary day):
+We simulate one of each in a clean epidemic and colour every day by its type (grey
+= ordinary day):
 
 ```{r tut-data, echo = FALSE}
 tut_cols <- c(Normal = "grey72", Hold = "#4E79A7",
@@ -454,11 +447,11 @@ ggplot(scores, aes(creation_z, transport_z, colour = kind)) +
   scale_y_continuous(expand = expansion(mult = c(0.05, 0.14))) +
   scale_x_continuous(expand = expansion(mult = 0.09)) +
   annotate("text", x = 8, y = ty + 3, size = 3, fontface = "bold",
-           colour = tut_cols[["Batch"]], label = "Backlog release: shoots UP and RIGHT") +
-  annotate("text", x = rx * 0.72, y = 4, size = 3, fontface = "bold",
-           colour = tut_cols[["Surge"]], label = "Real surge:\nshoots RIGHT") +
-  annotate("text", x = lx * 0.55, y = 21, size = 3, fontface = "bold",
-           colour = tut_cols[["Hold"]], label = "Hold:\ngoes UP and to the LEFT") +
+           colour = tut_cols[["Batch"]], label = "Batch: shoots UP and RIGHT") +
+  annotate("text", x = 20, y = -5, size = 3, fontface = "bold",
+           colour = tut_cols[["Surge"]], label = "Surge:\nshoots RIGHT") +
+  annotate("text", x = lx * 0.55, y = -10, size = 3, fontface = "bold",
+           colour = tut_cols[["Hold"]], label = "Hold:\ngoes goes DOWN") +
   labs(x = "Creation score",
        y = "Transport score",
        title = "2. Where each day lands in the transport-vs-creation plane") +
@@ -468,11 +461,11 @@ ggplot(scores, aes(creation_z, transport_z, colour = kind)) +
 
 Identifying any bar with its dot we can conclude:
 
-- A **batch (backlog release, red)** shoots **up** -- the days before were
+- A **batch (backlog release, red)** shoots **up and right** -- the days before were
   depleted (high transport) but not as many new cases were created (right);
 - A **surge (green)** shoots **right** -- cases genuinely appeared (high
   creation), with apparent preceding hole;
-- A **hold (blue)** drifts **up and to the left** -- reports have apparently gone
+- A **hold (blue)** drifts **left** -- reports have apparently gone
 missing (transport rising) while the window has *lost* cases (creation negative).
 
 Ordinary days (grey) sit in the cloud through the middle. That is the whole idea
@@ -540,6 +533,8 @@ batch_test(tn, period = 7) %>%
   arrange(desc(reported))
 ```
 
+The sensitivity of the batch flag can be adapted with `alpha`. 
+
 
 ## Delay changes 
 
@@ -564,14 +559,14 @@ plot_delay_drift(tn)
 ```
 
 The functions `test_delay_drift()` and `test_delay_changepoint()` test 
-for a gradual or abrupt changes in the delay. We can see, for example, that it correctly identifies the drift in the COVID-19 dataset that is not present in the ideal example:
+for a gradual or abrupt changes in the delay. We can see, for example, that it correctly identifies the drift in the COVID-19 dataset both for the median (trend) and the spread (see the quantiles getting tighter). On the ideal example this doesn't happen so it does not detect a drift:
 
 ```{r, warning=FALSE}
 test_delay_drift(tn)
 test_delay_drift(ideal)
 ```
 
-while it also finds the June change-point in the COVID-19 delay distribution which fails to be sustained for long enought to be detected in the ideal example: 
+The change-point function also detects that by April the COVID-19 delay distribution has completely changed from before. In the case of the ideal example the change is not  long enough to be detected: 
 
 ```{r, warning=FALSE}
 test_delay_changepoint(tn)


### PR DESCRIPTION
Improve v_triangle visualization by repositioning axis title annotations for better date readability and changing point shapes from 25 to 12. Fix styling and documentation in the batch reporting vignette, including typo corrections, improved explanations, and better code chunk evaluation settings.